### PR TITLE
lib: fix missing require

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 var child = require('child_process');
+var fs = require('fs');
 var path = require('path');
 var util = require('util');
 var which = require('which');


### PR DESCRIPTION
A function from the fs module is being used here: https://github.com/caspervonb/node-compiler_process/blob/master/lib/index.js#L109

But the fs module wasn't required.
